### PR TITLE
Support opam findlib + system compiler

### DIFF
--- a/main.ml
+++ b/main.ml
@@ -253,6 +253,11 @@ let write_header ~pos ~source ~source_option ~verbose ~prog_file lines =
   let file, oc = Filename.open_temp_file "meta" ".ml" in
   fprintf oc "\
 #%i %S;;
+(* Opam installations of findlib place topfind in a different directory *)
+let () =
+  try Topdirs.dir_directory (Sys.getenv \"OCAML_TOPLEVEL_PATH\")
+  with Not_found -> ()
+;;
 #use \"topfind\";;
 #require \"ocamlscript\";;
 Ocamlscript.Common.verbose := %s;;


### PR DESCRIPTION
When findlib is installed via opam as a normal user, it cannot
install 'topfind' in the system compiler's directory. Instead
opam will set the environment variable OCAML_TOPLEVEL_PATH to point
to it and add some runes to .ocamlinit.

This patch adds the same runes to the generated OCaml code before the
'#use topfind' line.

See ocaml/opam#45
