### PR TITLE
std module, to support no merlin errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ VERSION = 2.0.4
 RESULT = ocamlscript
 SOURCES = \
   version.ml pipeline.mli pipeline.ml common.mli common.ml \
-  utils.mli utils.ml ocaml.mli ocaml.ml
+  utils.mli utils.ml ocaml.mli ocaml.ml std.ml
 
 CAMLP4 := $(shell ocamlfind query camlp4)
 

--- a/examples/no-merlin-errors.ml
+++ b/examples/no-merlin-errors.ml
@@ -1,0 +1,15 @@
+#!/usr/bin/env ocamlscript
+let open Ocamlscript.Std in (** Inclues Ocamlscript and special (--) operator *)
+begin 
+  Ocaml.packs := ["cmdliner"]
+end
+-- 
+(* ^^^ opened as infix operator here, returning a unit.
+ * Must be on its own line! *)
+() (* need to close out the -- operator *)
+
+let f x y = x + 1 (* can parse basic staements after the () *)
+
+let arg_info = Cmdliner.Arg.info (* ensure packs are present *)
+
+let () = print_endline "look ma, no merlin errors!"

--- a/std.ml
+++ b/std.ml
@@ -1,0 +1,5 @@
+module Common = Common
+module Pipeline = Pipeline
+module Ocaml = Ocaml
+module Utils = Utils
+let (--) _ _ = ()


### PR DESCRIPTION
This introduces a module that encompases all the `Ocamlscript` modules as well as
this operator: 

``` OCaml
val (--) : 'a -> 'b -> unit
```

which is used to get the ocamlscript header through the merlin compiler without errors, such as with [this example](https://github.com/mjambon/ocamlscript/blob/b368bd16b0c89741205186b828aece84d3840b82/examples/no-merlin-errors.ml). 

Note this still requires having a `.merlin` file, although I'm considering ways around that too. Before this change, you simply couldn't avoid getting an error on the terminating `--` line.
